### PR TITLE
Bump actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -197,7 +197,7 @@ jobs:
           echo "::set-output name=id::$id"
       - name: Upload test videos and screenshots on test failure
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.mode }}-${{steps.extract-spec-filename.outputs.id}}-${{ env.NODE_VERSION }}
           path: |


### PR DESCRIPTION
## Changelog

### Added

### Changed

- Per https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

### Deprecated

### Removed

### Fixed

### Security

## Checklist

- [ ] Test
- [ ] Self-review
- [ ] Documentation
